### PR TITLE
Add support for boxed iterators

### DIFF
--- a/src/sorted_iterator.rs
+++ b/src/sorted_iterator.rs
@@ -6,6 +6,8 @@ use core::iter::Peekable;
 use core::{iter, ops};
 use std::collections;
 use std::collections::BinaryHeap;
+use std::rc::Rc;
+use std::sync::Arc;
 
 /// marker trait for iterators that are sorted by their Item
 pub trait SortedByItem {}
@@ -399,6 +401,8 @@ impl<I: Iterator, J: Iterator> SortedByItem for Difference<I, J> {}
 impl<I: Iterator, J: Iterator> SortedByItem for SymmetricDifference<I, J> {}
 impl<I: Iterator> SortedByItem for MultiwayUnion<I> {}
 
+impl<I: SortedByItem> SortedByItem for Box<I> {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -538,6 +542,8 @@ mod tests {
         is_s(0i64..10);
         is_s(0i64..=10);
         is_s(0i64..);
+        // wrappers
+        is_s(Box::new(0i64..10));
         // identity
         is_s(s().fuse());
         is_s(r().cloned());

--- a/src/sorted_pair_iterator.rs
+++ b/src/sorted_pair_iterator.rs
@@ -363,6 +363,8 @@ impl<'a, K, V> SortedByKey for collections::btree_map::IterMut<'a, K, V> {}
 impl<'a, K, V> SortedByKey for collections::btree_map::Range<'a, K, V> {}
 impl<'a, K, V> SortedByKey for collections::btree_map::RangeMut<'a, K, V> {}
 
+impl<I: SortedByKey> SortedByKey for Box<I> {}
+
 #[cfg(test)]
 mod tests {
     extern crate maplit;
@@ -493,6 +495,8 @@ mod tests {
         is_s((0i64..10).pairs());
         is_s((0i64..=10).pairs());
         is_s((0i64..).pairs());
+        // wrappers
+        is_s(Box::new((0i64..).pairs()));
         // skip/take/step/filter
         is_s(s().step_by(1));
         is_s(s().take(1));


### PR DESCRIPTION
If an iterator is sorted, boxing it will keep the invariant.

Implements #4