### PR TITLE
Pass-thru impls for AssumeSortedByItem and AssumeSortedByKey.

### DIFF
--- a/src/sorted_iterator.rs
+++ b/src/sorted_iterator.rs
@@ -6,6 +6,7 @@ use core::iter::Peekable;
 use core::{iter, ops};
 use std::collections;
 use std::collections::BinaryHeap;
+use std::iter::FusedIterator;
 
 /// marker trait for iterators that are sorted by their Item
 pub trait SortedByItem {}
@@ -359,6 +360,16 @@ impl<I: Iterator> Iterator for AssumeSortedByItem<I> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.i.size_hint()
+    }
+}
+
+impl<I: Iterator> ExactSizeIterator for AssumeSortedByItem<I> where I: ExactSizeIterator {}
+
+impl<I: Iterator> FusedIterator for AssumeSortedByItem<I> where I: FusedIterator {}
+
+impl<I: Iterator> DoubleEndedIterator for AssumeSortedByItem<I> where I: DoubleEndedIterator {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.i.next_back()
     }
 }
 

--- a/src/sorted_pair_iterator.rs
+++ b/src/sorted_pair_iterator.rs
@@ -8,7 +8,7 @@ use core::{
     iter,
     iter::Peekable,
 };
-use std::collections;
+use std::{collections, iter::FusedIterator};
 
 /// marker trait for iterators that are sorted by the key of their Item
 pub trait SortedByKey {}
@@ -322,6 +322,19 @@ impl<I: Iterator> Iterator for AssumeSortedByKey<I> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.i.size_hint()
+    }
+}
+
+impl<I: Iterator> ExactSizeIterator for AssumeSortedByKey<I> where I: ExactSizeIterator {}
+
+impl<I: Iterator> FusedIterator for AssumeSortedByKey<I> where I: FusedIterator {}
+
+impl<I: Iterator> DoubleEndedIterator for AssumeSortedByKey<I>
+where
+    I: DoubleEndedIterator,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.i.next_back()
     }
 }
 


### PR DESCRIPTION
Implement `ExactSizeIterator`, `FusedIterator`, and `DoubleEndedIterator` for `AssumeSortedByItem` and `AssumeSortedByKey`. This is consistent with the approach in the standard library, e.g., `std::iter::Map`.